### PR TITLE
Add .cjs extensions to activationEvents globs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,13 @@
   },
   "activationEvents": [
     "workspaceContains:**/tailwind.js",
+    "workspaceContains:**/tailwind.cjs",
     "workspaceContains:**/tailwind.config.js",
+    "workspaceContains:**/tailwind.config.cjs",
     "workspaceContains:**/tailwind-config.js",
-    "workspaceContains:**/.tailwindrc.js"
+    "workspaceContains:**/tailwind-config.cjs",
+    "workspaceContains:**/.tailwindrc.js",
+    "workspaceContains:**/.tailwindrc.cjs"
   ],
   "contributes": {
     "configuration": {


### PR DESCRIPTION
This comes up in projects where the root package.json has `"module": true`.